### PR TITLE
feat: Add password-based authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,17 @@
 module github.com/audetic/godeploy
 
-go 1.22.5
+go 1.23.0
+
+toolchain go1.24.5
 
 require github.com/alecthomas/kong v1.9.0
 
 require github.com/gosimple/slug v1.15.0
+
+require (
+	golang.org/x/sys v0.35.0 // indirect
+	golang.org/x/term v0.34.0 // indirect
+)
 
 require (
 	github.com/gosimple/unidecode v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,3 +12,7 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/yarlson/pin v0.9.0 h1:qwmI/ots8N7d27NHEltzRpTvLAUX5vAoWaLBqiyqB2A=
 github.com/yarlson/pin v0.9.0/go.mod h1:FC/d9PacAtwh05XzSznZWhA447uvimitjgDDl5YaVLE=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.34.0 h1:O/2T7POpk0ZZ7MAzMeWFSg6S5IpWd/RXDlM9hgM3DR4=
+golang.org/x/term v0.34.0/go.mod h1:5jC53AEywhIVebHgPVeg0mj8OD3VO9OzclacVrqpaAw=


### PR DESCRIPTION
## Summary
Implements password-based authentication to replace the magic link flow, aligning with the new authentication endpoints added in silvabyte/godeploy-api#8.

## Changes

### 🔐 New Authentication Flow
- **Password Authentication**: Direct username/password authentication replacing email magic links
- **Sign Up Command**: New `godeploy auth sign-up` command for account creation
- **Interactive Prompts**: Secure password input with masking using `golang.org/x/term`

### 📝 API Integration
- `POST /api/auth/signin` - Sign in with email/password
- `POST /api/auth/signup` - Create new account
- Proper HTTP status codes (200 OK, 201 Created, 401 Unauthorized)
- JWT token returned immediately upon successful authentication

### 🛠️ Implementation Details

#### New Commands
```bash
# Sign in with existing account
godeploy auth login --email=user@example.com --password=mypassword
godeploy auth login  # Interactive mode - prompts for credentials

# Create new account
godeploy auth sign-up --email=newuser@example.com --password=securepass123
godeploy auth sign-up  # Interactive mode with password confirmation
```

#### Security Features
- Minimum 8-character password requirement
- Password confirmation for sign-up in interactive mode
- Secure password input (masked/hidden)
- Clear error messages for invalid credentials

#### Code Changes
- Added `SignIn()` and `SignUp()` methods to API client
- Updated `LoginCmd` to use password instead of magic link
- Added new `SignUpCmd` for account registration
- Removed OAuth callback server dependency
- Updated error handling for authentication failures

### 🔄 Backward Compatibility
- Token storage mechanism unchanged
- Existing authenticated users remain logged in
- `auth status` and `auth logout` commands work as before
- Saved email addresses still used for convenience

### 🧪 Testing
- [x] Manual testing of sign in flow
- [x] Manual testing of sign up flow
- [x] Interactive password prompts
- [x] Error handling for invalid credentials
- [x] Token persistence after authentication

## Related Issues
- Implements password authentication as discussed in silvabyte/godeploy-api#8

## Breaking Changes
None for existing authenticated users. New users will use password authentication instead of magic links.

## Migration Notes
Users who previously authenticated with magic links can:
1. Continue using their existing tokens
2. Set a password through the API's password reset flow (not yet implemented in CLI)
3. Create a new account with `godeploy auth sign-up` if needed